### PR TITLE
Add in the "xy" moment to better constrain source shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Auto generated files
+oarfish/git_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE
 recursive-include oarfish *
+include oarfish/git_version.py
 recursive-include scripts *
 global-exclude *~ *.bak *.py[cod] __pycache__

--- a/oarfish/__init__.py
+++ b/oarfish/__init__.py
@@ -4,6 +4,8 @@ import sys
 import os
 from pathlib import Path
 
+from .git_version import *
+
 def _get_code_checksum() -> str:
     """Create a checksum of all relevant module files"""
     modules = ['data', 'utils', 'train', 'classify', 'predict']
@@ -18,3 +20,4 @@ def _get_code_checksum() -> str:
     return ",".join(checksums)
 
 CODE_CHECKSUM = _get_code_checksum()
+REPO_INFO = f"{GIT_BRANCH}@{GIT_HASH[:7]}-{GIT_STATUS}"

--- a/oarfish/data.py
+++ b/oarfish/data.py
@@ -135,11 +135,14 @@ class LWATVDataset(Dataset):
         sky_i, sky_v = extract_sky(stokes_i, stokes_v, topo_wcs) 
         hrz_i, hrz_v = extract_horizon(stokes_i, stokes_v, wcs)
         byd_i, byd_v = extract_beyond_horizon(stokes_i, stokes_v, topo_wcs)
-        srcs = extract_sources(stokes_i, stokes_v, timestamp, wcs, location=location)
-        sun = extract_sun(stokes_i, stokes_v, timestamp, wcs, location=location)
+        srcs = extract_sources(stokes_i, stokes_v, timestamp, wcs,
+                               location=location, window_size=15)
+        sun = extract_sun(stokes_i, stokes_v, timestamp, wcs,
+                          location=location, window_size=15)
         jupiter = {}
         if metadata['start_freq'] <= 40e6:
-            jupiter = extract_jupiter(stokes_i, stokes_v, timestamp, wcs, location=location)
+            jupiter = extract_jupiter(stokes_i, stokes_v, timestamp, wcs,
+                                      location=location, window_size=15)
         
         # Analyze astronoical features
         sky = characterize_sky(sky_i, sky_v)
@@ -295,9 +298,12 @@ class MultiChannelDataset(LWATVDataset):
         sky_i, sky_v = extract_sky(stokes_i, stokes_v, topo_wcs) 
         hrz_i, hrz_v = extract_horizon(stokes_i, stokes_v, wcs)
         byd_i, byd_v = extract_beyond_horizon(stokes_i, stokes_v, topo_wcs)
-        srcs = extract_sources(stokes_i, stokes_v, timestamp, wcs, location=location)
-        sun = extract_sun(stokes_i, stokes_v, timestamp, wcs, location=location)
-        jupiter = extract_jupiter(stokes_i, stokes_v, timestamp, wcs, location=location)
+        srcs = extract_sources(stokes_i, stokes_v, timestamp, wcs,
+                               location=location, window_size=15)
+        sun = extract_sun(stokes_i, stokes_v, timestamp, wcs,
+                          location=location, window_size=15)
+        jupiter = extract_jupiter(stokes_i, stokes_v, timestamp, wcs,
+                                  location=location, window_size=15)
         for c in range(nchan):
             f = metadata['start_freq'] + c*metadata['bandwidth']
             if f > 40e6:

--- a/oarfish/train.py
+++ b/oarfish/train.py
@@ -13,7 +13,7 @@ from torch.utils.data import DataLoader, WeightedRandomSampler
 
 from sklearn.model_selection import KFold
 
-from . import CODE_CHECKSUM
+from . import CODE_CHECKSUM, REPO_INFO
 from .data import LWATVDataset
 from .classify import BinaryLWATVClassifier, MultiLWATVClassifier
 
@@ -65,6 +65,7 @@ class ModelTrainer:
         os.makedirs(path, exist_ok=True)
         checkpoint = {
             'code_checksum': CODE_CHECKSUM,
+            'repo_info': REPO_INFO,
             'epoch': epoch,
             'model_state_dict': self.model.state_dict(),
             'optimizer_state_dict': self.optimizer.state_dict(),
@@ -87,6 +88,11 @@ class ModelTrainer:
                 print("Warning: checksum mis-match between software and checkpoint data")
         else:
             print("Warning: no checksum found in the checkpoint data")
+        if 'repo_info' in checkpoint:
+            if checkpoint['repo_info'] != REPO_INFO:
+                print("Warning: git repo info mis-match between software and checkpoint data")
+        else:
+            print("Warning: no git repo info found in the checkpoint data")
         self.model.load_state_dict(checkpoint['model_state_dict'])
         self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
         return checkpoint['epoch']

--- a/oarfish/utils.py
+++ b/oarfish/utils.py
@@ -296,7 +296,7 @@ def characterize_beyond_horizon(byd_i: np.ndarray, byd_v: np.ndarray) -> Union[D
 
 
 def extract_sources(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time, wcs: WCS,
-                    location: Optional[EarthLocation]=None,
+                    location: Optional[EarthLocation]=None, window_size: int=15,
                     srcs: List[str]=['CygA', 'CasA', 'TauA', 'VirA']) -> Union[Dict[str, List[np.ndarray]],
                                                                                List[Dict[str, np.ndarray]]]:
     """
@@ -310,6 +310,10 @@ def extract_sources(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time,
         stokes_i = stokes_i.reshape(1, *stokes_i.shape)
         stokes_v = stokes_v.reshape(1, *stokes_v.shape)
     nchan, xsize, ysize = stokes_i.shape
+    
+    if window_size % 2 == 0:
+        window_size += 1
+    wpad = window_size //2
     
     pc = wcs.pixel_to_world(*(wcs.wcs.crpix-1))
     srcs_xy = {}
@@ -332,8 +336,8 @@ def extract_sources(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time,
     for c in range(nchan):
         regions = {}
         for src,(y,x) in srcs_xy.items():
-            regions[src] = [stokes_i[c, x-7:x+8, y-7:y+8],
-                            stokes_v[c, x-7:x+8, y-7:y+8]]
+            regions[src] = [stokes_i[c, x-wpad:x+wpad+1, y-wpad:y+wpad+1],
+                            stokes_v[c, x-wpad:x+wpad+1, y-wpad:y+wpad+1]]
         results.append(regions)
         
     if reshape_needed:
@@ -343,8 +347,9 @@ def extract_sources(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time,
 
 
 def extract_sun(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time, wcs: WCS,
-                location: Optional[EarthLocation]=None) -> Union[Dict[str, List[np.ndarray]],
-                                                                 List[Dict[str, np.ndarray]]]:
+                location: Optional[EarthLocation]=None,
+                window_size: int=15) -> Union[Dict[str, List[np.ndarray]],
+                                              List[Dict[str, np.ndarray]]]:
     """
     Similar to extract_sources but only works on the Sun.
     """
@@ -355,6 +360,10 @@ def extract_sun(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time, wcs
         stokes_i = stokes_i.reshape(1, *stokes_i.shape)
         stokes_v = stokes_v.reshape(1, *stokes_v.shape)
     nchan, xsize, ysize = stokes_i.shape
+    
+    if window_size % 2 == 0:
+        window_size += 1
+    wpad = window_size //2
     
     pc = wcs.pixel_to_world(*(wcs.wcs.crpix-1))
         
@@ -368,8 +377,8 @@ def extract_sun(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time, wcs
         regions = {}
         if d.deg <= HORIZON_ZA_DEG:
             y, x = int(round(sun_y.item())), int(round(sun_x.item()))
-            regions['sun'] = [stokes_i[c, x-7:x+8, y-7:y+8],
-                              stokes_v[c, x-7:x+8, y-7:y+8]]
+            regions['sun'] = [stokes_i[c, x-wpad:x+wpad+1, y-wpad:y+wpad+1],
+                              stokes_v[c, x-wpad:x+wpad+1, y-wpad:y+wpad+1]]
             if regions['sun'][0].size == 0:
                 del regions['sun']
         results.append(regions)
@@ -381,8 +390,9 @@ def extract_sun(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time, wcs
 
 
 def extract_jupiter(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time, wcs: WCS,
-                    location: Optional[EarthLocation]=None) -> Union[Dict[str, List[np.ndarray]],
-                                                                     List[Dict[str, np.ndarray]]]:
+                    location: Optional[EarthLocation]=None,
+                    window_size: int=15) -> Union[Dict[str, List[np.ndarray]],
+                                                  List[Dict[str, np.ndarray]]]:
     """
     Similar to extract_sources but only works on Jupiter.
     """
@@ -393,6 +403,10 @@ def extract_jupiter(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time,
         stokes_i = stokes_i.reshape(1, *stokes_i.shape)
         stokes_v = stokes_v.reshape(1, *stokes_v.shape)
     nchan, xsize, ysize = stokes_i.shape
+    
+    if window_size % 2 == 0:
+        window_size += 1
+    wpad = window_size //2
     
     pc = wcs.pixel_to_world(*(wcs.wcs.crpix-1))
     
@@ -406,8 +420,8 @@ def extract_jupiter(stokes_i: np.ndarray, stokes_v: np.ndarray, timestamp: Time,
         regions = {}
         if d.deg <= HORIZON_ZA_DEG: 
             y, x = int(round(jupiter_y.item())), int(round(jupiter_x.item()))
-            regions['jupiter'] = [stokes_i[c, x-7:x+8, y-7:y+8],
-                                  stokes_v[c, x-7:x+8, y-7:y+8]]
+            regions['jupiter'] = [stokes_i[c, x-wpad:x+wpad+1, y-wpad:y+wpad+1],
+                                  stokes_v[c, x-wpad:x+wpad+1, y-wpad:y+wpad+1]]
             if regions['jupiter'][0].size == 0:
                 del regions['jupiter']
         results.append(regions)
@@ -426,7 +440,8 @@ def characterize_sources(regions: Union[Dict[str, float], List[Dict[str, float]]
      * Number of sources analyzed
      * The peak background subtracted flux measured
      * Average ratio of the background to the peak flux
-     * Average ratio of the X to Y FWHM estimates
+     * Average ratio of the minor to major axes FWHM estimates
+     * Average value of the position angle of the major axis
      * Average ratio of Stokes |V| to I at the Stokes I peak location
     """
     

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,41 @@
 import os
 import glob
 import shutil
+import subprocess
 
 from setuptools import setup, find_namespace_packages
+
+
+def get_git_info():
+      try:
+            git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+                                               text=True)
+            git_hash = git_hash.strip()
+            git_brnc = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                                               text=True)
+            git_brnc = git_brnc.strip()
+            git_stat = subprocess.check_output(['git', 'status', '--porcelain'],
+                                                text=True)
+            git_stat = 'dirty' if git_stat.strip() else 'clean'
+      except (OSError, subprocess.CalledProcessError):
+            git_hash = git_brnc = git_stat = 'unknown'
+            
+      return git_hash, git_brnc, git_stat
+
+
+def write_version_info():
+      ghash, gbrnc, gstat = get_git_info()
+      with open(os.path.join('oarfish', 'git_version.py'), 'w') as fh:
+            fh.write(f"""
+# This is an automatically generated file, do not edit
+GIT_BRANCH = '{gbrnc}'
+GIT_HASH = '{ghash}'
+GIT_STATUS = '{gstat}'
+""")
+
+
+write_version_info()
+
 
 setup(name                 = "oarfish",
       version              = "0.1.0",


### PR DESCRIPTION
The current implementation of `utils.characterize_sources()` only considers the x and y directions when estimating the source shape.  This doesn't really work in practice because any elongation isn't likely to purely in x or y.  This PR adds the xy cross term so that the orientation and minor/major axis ratio can be obtained.

As a secondary thing this PR also introduces a `window_size` keyword to `utils.extract_sources()`, `utils.extract_sun()`, and `utils.extract_jupiter()` to give users more control over the extraction size.